### PR TITLE
fix link to book

### DIFF
--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -4,6 +4,6 @@ Welcome to the Hickory DNS User Manual. This book will be updated as issues and 
 
 In some cases the best source of information about how to use the project is in the source repository, [Hickory DNS](https://github.com/hickory-dns/hickory-dns).
 
-Contributions to this book will always be welcome, [Hickory Docs](https://github.com/hickory-dns/hickory-docs/book).
+Contributions to this book will always be welcome, [Hickory Docs](https://github.com/hickory-dns/hickory-dns.github.io/tree/main/book).
 
 Thank you to the [Rust](https://www.rust-lang.org) community for making this project possible.


### PR DESCRIPTION
it appears that the repository was renamed